### PR TITLE
Fix in case request_path is missing

### DIFF
--- a/lib/griddler/ses/middleware.rb
+++ b/lib/griddler/ses/middleware.rb
@@ -22,7 +22,8 @@ module Griddler
       end
 
       def is_griddler_request?(request)
-        request['REQUEST_PATH'] == griddler_path
+        # Fix for servers that do not include 'request_path' in headers
+        request['REQUEST_PATH'] == griddler_path || request['REQUEST_URI'] == griddler_path
       end
 
       def is_aws_sns_request?(request)


### PR DESCRIPTION
On my server, the header 'request_path' was missing, which in turn broke the middleware because the content type would not get changed to 'application/json'. So added in check for 'request_uri' as well, which fixes the middleware issue.