### PR TITLE
Encoding::CompatibilityError fix

### DIFF
--- a/lib/griddler/amazon_ses/adapter.rb
+++ b/lib/griddler/amazon_ses/adapter.rb
@@ -84,11 +84,15 @@ module Griddler
       end
 
       def text_part
-        multipart? ? message.text_part.body.to_s : message.body.to_s
+        force_body_to_utf_8_string(multipart? ? message.text_part.body : message.body)
       end
 
       def html_part
-        multipart? ? message.html_part.body.to_s : nil
+        multipart? ? force_body_to_utf_8_string(message.html_part.body) : nil
+      end
+
+      def force_body_to_utf_8_string(message_body)
+        message_body.to_s.force_encoding(Encoding::UTF_8)
       end
 
       def raw_headers

--- a/spec/griddler/amazon_ses_spec.rb
+++ b/spec/griddler/amazon_ses_spec.rb
@@ -38,6 +38,10 @@ describe Griddler::AmazonSES::Adapter do
     it 'parses out the text' do
       expect(Griddler::AmazonSES::Adapter.normalize_params(default_params)[:text]).to eq "Hi\n"
     end
+
+    it 'should return the text body in UTF-8' do
+      expect(Griddler::AmazonSES::Adapter.normalize_params(default_params)[:text].encoding.to_s).to eq "UTF-8"
+    end
   end
 
   let(:default_params) {


### PR DESCRIPTION
Addressing issues due to decode64 returning an US-ASCII encoded string (see: thoughtbot/griddler#304).

Griddler email parsing expects a string in UTF-8.